### PR TITLE
FIX: TinyMCE useRef 사용 방식으로 인해 빌드 실패하는 이슈 수정

### DIFF
--- a/pages/demo/tinymce.tsx
+++ b/pages/demo/tinymce.tsx
@@ -1,10 +1,11 @@
-import { Editor } from '@tinymce/tinymce-react';
-import React, { useRef } from 'react';
+import { Editor as TinyMCEReact } from '@tinymce/tinymce-react';
+import React, {  useState } from 'react';
+import { Editor } from 'tinymce';
 
 import { Layout } from '@/components/Layout';
 
 const TinymceEditor = () => {
-  const editorRef = useRef<Editor>(null);
+  const [editor, setEditor] = useState<Editor>();
   const tinymcePlugins = ['link', 'lists', 'autoresize', 'image'];
   const tinymceToolbar =
     'blocks fontfamily |' +
@@ -14,8 +15,8 @@ const TinymceEditor = () => {
 
   return (
     <Layout>
-      <Editor
-        onInit={(_, editor) => (editorRef.current = editor)}
+      <TinyMCEReact
+        onInit={(_, editor) => (setEditor(editor))}
         init={{
           plugins: tinymcePlugins,
           toolbar: tinymceToolbar,
@@ -26,6 +27,7 @@ const TinymceEditor = () => {
           block_formats: '제목1=h2;제목2=h3;제목3=h4;본문=p;',
           image_caption: true,
         }}
+        onEditorChange={() => { console.log(editor?.getContent()); }}
       />
     </Layout>
   );


### PR DESCRIPTION
## 요약
- [잘못된 useRef 사용 형태로 인해 발생한 에러로 인해 빌드가 실패하는 이슈](https://github.com/You-HI/youhi-web-fe/pull/13#discussion_r1368758264) 수정
- `useRef`가 아닌, `useState`를 사용하는 형태로 수정
<!--- PR 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다. -->

## 배경

<!--- PR의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다. -->

## 목표

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. -->

## 참고 자료

<!-- 참고 자료를 나열합니다. -->

## 종류

- [ ] FEAT: 새로운 기능의 추가
- [ ] FIX: 버그 수정
- [ ] DOCS: 문서 수정
- [ ] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 코드, 리팩토링 테스트 코드 추가
- [ ] CHORE: 빌드 업무 수정, 패키지 매니저 수정 등 (gitignore 등 포함)
- [ ] REVIEW: 코드 리뷰 반영
